### PR TITLE
Docs: move version selector to header via mike (site+docs mkdocs.yml)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -17,6 +17,14 @@
 
 site_name: docs/latest
 
+extra:
+  version:
+    provider: mike
+    # optional niceties (safe defaults):
+    default: latest
+    alias: true
+
+
 plugins:
   - search
 


### PR DESCRIPTION
### What
Enable the Material-for-MkDocs header version selector by configuring mike as the version provider.

### Why
Iceberg docs are versioned; using the standard header selector reduces left-nav clutter and matches common docs UX.

### How
- site/mkdocs.yml: add `extra.version.provider: mike`
- docs/mkdocs.yml: add `extra.version.provider: mike`
- Remove any redundant sidebar version widget if present.

### Notes
Material renders the selector only when versions are deployed via mike (e.g., `mike serve` locally); this is expected.

Closes #13616